### PR TITLE
Improve PDF rendering performance and resource management

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,0 +1,18 @@
+### I use this readme as a notepad for now
+
+
+
+### To be investigated
+
+`Long monitor contention with owner DefaultDispatcher-worker-9 (32596) at void android.graphics.pdf.PdfRenderer$Page.render(...) waiters=6 ... for 162ms`
+
+This tells us that:
+1. Six threads are waiting to access the renderer
+2. They're waiting for significant periods (162ms to 1.924s)
+3. The contention is happening primarily in two places:
+   `PdfRenderer$Page.render()`
+   `PdfRenderer$Page.<init>() (the page initialization)`
+
+The root cause is that Android's PdfRenderer has internal synchronization that we didn't account for in our concurrent design.
+Even though we're using different renderer instances, they're still experiencing contention.
+This suggests that there might be some shared native resources that all PdfRenderer instances are competing for??

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -71,6 +71,7 @@ dependencies {
     testImplementation(libs.koin.test.junit4)
     testImplementation(libs.mockk)
     testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.assertj.core)
 
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)

--- a/app/src/main/java/com/asaad27/qraya/data/repository/IPdfReaderRepository.kt
+++ b/app/src/main/java/com/asaad27/qraya/data/repository/IPdfReaderRepository.kt
@@ -10,6 +10,6 @@ interface IPdfReaderRepository {
     suspend fun renderPage(pageIndex: Int, width: Int, height: Int): Result<Bitmap>
     suspend fun renderPages(pages: List<Int>, width: Int, height: Int): Result<List<Bitmap>>
     fun renderPagesFlow(pages: List<Int>, width: Int, height: Int): Flow<Result<Pair<Int, Bitmap>>>
-    fun cleanup()
+    suspend fun cleanup()
 }
 

--- a/app/src/main/java/com/asaad27/qraya/data/repository/IPdfRenderer.kt
+++ b/app/src/main/java/com/asaad27/qraya/data/repository/IPdfRenderer.kt
@@ -1,7 +1,6 @@
 package com.asaad27.qraya.data.repository
 
-interface IPdfRenderer {
+interface IPdfRenderer: AutoCloseable {
     val pageCount: Int
     fun openPage(index: Int): IPdfPage
-    fun close()
 }

--- a/app/src/main/java/com/asaad27/qraya/data/repository/PdfReaderRepository.kt
+++ b/app/src/main/java/com/asaad27/qraya/data/repository/PdfReaderRepository.kt
@@ -6,14 +6,24 @@ import android.graphics.Matrix
 import android.graphics.pdf.PdfRenderer
 import android.net.Uri
 import android.os.ParcelFileDescriptor
+import android.util.Log
 import com.asaad27.qraya.data.model.PdfInfo
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.util.concurrent.ConcurrentLinkedQueue
+import kotlin.time.Duration
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
 
 class PdfReaderRepository(
     private val applicationContext: Context,
@@ -26,37 +36,46 @@ class PdfReaderRepository(
     private val matrixFactory: () -> Matrix = { Matrix() }
 ) : IPdfReaderRepository {
 
-    private var fileDesc: ParcelFileDescriptor? = null
-    private var renderer: IPdfRenderer? = null
+    private val rendererPoolSize: Int = Runtime.getRuntime().availableProcessors()
+    private val rendererPool = Channel<IPdfRenderer>(Channel.UNLIMITED)
+    private val activeRenderers = ConcurrentLinkedQueue<IPdfRenderer>()
+    private var currentUri: Uri? = null
+    private var fileDescriptor: ParcelFileDescriptor? = null
 
     override suspend fun loadPdf(uri: Uri): Result<PdfInfo> = withContext(dispatcher) {
         runCatching {
-            cleanup()
+            currentUri = uri
 
-            fileDesc = applicationContext.contentResolver.openFileDescriptor(uri, "r")?.also {
-                renderer = rendererFactory(it)
-            } ?: throw Exception("Failed to open PDF file descriptor")
+            val fd = applicationContext.contentResolver.openFileDescriptor(uri, "r")
+                ?: throw Exception("Failed to open PDF file descriptor")
+            fileDescriptor = fd
 
-            PdfInfo(pageCount = renderer?.pageCount ?: 0)
+            // Initialize a temporary renderer to get page count
+            val tempRenderer = rendererFactory(ParcelFileDescriptor.dup(fd.fileDescriptor))
+            val pageCount = tempRenderer.pageCount
+            tempRenderer.close()
+
+            // Initialize renderer pool
+            repeat(rendererPoolSize) {
+                val clonedFd = ParcelFileDescriptor.dup(fd.fileDescriptor)
+                val renderer = rendererFactory(clonedFd)
+                activeRenderers.add(renderer)
+                rendererPool.trySend(renderer)
+            }
+
+            PdfInfo(pageCount = pageCount)
         }
     }
+
 
     override suspend fun renderPage(
         pageIndex: Int,
         width: Int,
         height: Int
-    ): Result<Bitmap> {
-        return withContext(dispatcher) {
-            runCatching {
-                renderer?.openPage(pageIndex)?.use { page ->
-                    val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
-                    val matrix = matrixFactory().apply {
-                        setScale(width.toFloat() / page.width, height.toFloat() / page.height)
-                    }
-                    page.render(bitmap, null, matrix, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
-
-                    return@use bitmap
-                } ?: throw Exception("error during page rendering, null result")
+    ): Result<Bitmap> = withContext(dispatcher) {
+        runCatching {
+            withRenderer { renderer ->
+                renderPageInternal(pageIndex, width, height, renderer).getOrThrow()
             }
         }
     }
@@ -67,41 +86,105 @@ class PdfReaderRepository(
         height: Int
     ): Result<List<Bitmap>> = withContext(dispatcher) {
         runCatching {
-            val bitmaps = pages.map {
-                Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
-            }
-            pages.zip(bitmaps).map { (pageIndex, bitmap) ->
-                renderer?.openPage(pageIndex)?.use { page ->
-                    val matrix = matrixFactory().apply {
-                        setScale(width.toFloat() / page.width, height.toFloat() / page.height)
+            val batchSize = (pages.size + rendererPoolSize - 1) / rendererPoolSize
+            val batches = pages.chunked(batchSize)
+            val startTime = System.nanoTime()
+
+            Log.d("PdfReaderRepository", "started Rendering ${pages.size} pages in $batchSize batches")
+
+            coroutineScope {
+                batches.map { batch ->
+                    async {
+                        withRenderer { renderer ->
+                            batch.map { pageIndex ->
+                                renderPageInternal(pageIndex, width, height, renderer).getOrThrow()
+                            }
+                        }
                     }
-                    page.render(bitmap, null, matrix, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
-                } ?: throw Exception("Renderer is null")
+                }.awaitAll().flatten().also {
+                    Log.d("PdfReaderRepository", "finished Rendering ${pages.size} pages in $batchSize batches")
+
+                    val totalDurationNs = System.nanoTime() - startTime
+                    val totalDurationMs = totalDurationNs / 1_000_000
+                    val seconds = totalDurationMs / 1000
+                    val milliseconds = totalDurationMs % 1000
+                    Log.d("PdfReaderRepository", "took $seconds seconds and $milliseconds milliseconds to render $pages pages")
+                }
             }
-
-            bitmaps
         }
     }
 
+    override fun renderPagesFlow(
+        pages: List<Int>,
+        width: Int,
+        height: Int
+    ): Flow<Result<Pair<Int, Bitmap>>> = channelFlow {
+        val batchSize = (pages.size + rendererPoolSize - 1) / rendererPoolSize
+        val batches = pages.chunked(batchSize)
 
-override fun renderPagesFlow(
-    pages: List<Int>,
-    width: Int,
-    height: Int
-): Flow<Result<Pair<Int, Bitmap>>> = channelFlow {
-    pages.forEach { pageIndex ->
-        launch {
-            val result = renderPage(pageIndex, width, height)
-            send(result.map { pageIndex to it })
+        coroutineScope {
+            batches.forEach { batch ->
+                launch {
+                    withRenderer { renderer ->
+                        batch.forEach { pageIndex ->
+                            val result = renderPageInternal(pageIndex, width, height, renderer)
+                            send(result.map { pageIndex to it })
+                        }
+                    }
+                }
+            }
+        }
+    }.flowOn(dispatcher)
+
+
+    private fun renderPageInternal(
+        pageIndex: Int,
+        width: Int,
+        height: Int,
+        renderer: IPdfRenderer
+    ): Result<Bitmap> = runCatching {
+        Log.d("PdfReaderRepository", "Rendering page $pageIndex")
+        renderer.openPage(pageIndex).use { page ->
+            val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+            val matrix = matrixFactory().apply {
+                setScale(width.toFloat() / page.width, height.toFloat() / page.height)
+            }
+            page.render(bitmap, null, matrix, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
+            bitmap
+        }
+    }.also {
+        Log.d("PdfReaderRepository", "Page $pageIndex rendering completed")
+    }
+
+    @OptIn(DelicateCoroutinesApi::class)
+    override suspend fun cleanup() = withContext(dispatcher) {
+        activeRenderers.forEach { renderer ->
+            runCatching { renderer.close() }
+                .onFailure { Log.e("PdfReaderRepository", "Error closing renderer", it) }
+        }
+        activeRenderers.clear()
+
+        runCatching {
+            fileDescriptor?.close()
+            fileDescriptor = null
+        }.onFailure { Log.e("PdfReaderRepository", "Error closing file descriptor", it) }
+
+        currentUri = null
+
+        while (true) {
+            val renderer = rendererPool.tryReceive().getOrNull() ?: break
+            runCatching { renderer.close() }
+                .onFailure { Log.e("PdfReaderRepository", "Error closing pooled renderer", it) }
         }
     }
-}.flowOn(dispatcher)
 
-override fun cleanup() {
-    fileDesc?.close()
-    renderer?.close()
-    fileDesc = null
-    renderer = null
-}
+    private suspend fun <T> withRenderer(block: suspend (IPdfRenderer) -> T): T {
+        val renderer = rendererPool.receive()
+        try {
+            return block(renderer)
+        } finally {
+            rendererPool.send(renderer)
+        }
+    }
 }
 

--- a/app/src/main/java/com/asaad27/qraya/ui/pdf/viewmodel/PdfViewModel.kt
+++ b/app/src/main/java/com/asaad27/qraya/ui/pdf/viewmodel/PdfViewModel.kt
@@ -2,6 +2,7 @@ package com.asaad27.qraya.ui.pdf.viewmodel
 
 import android.graphics.Bitmap
 import android.net.Uri
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.asaad27.qraya.data.repository.IPdfReaderRepository
@@ -13,6 +14,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.supervisorScope
 
 class PdfViewModel(
     private val pdfReaderRepository: IPdfReaderRepository,
@@ -93,9 +96,15 @@ class PdfViewModel(
     }
 
     public override fun onCleared() {
-        super.onCleared()
-        viewModelScope.launch {
-            pdfReaderRepository.cleanup()
+        runBlocking {
+            supervisorScope {
+                try {
+                    pdfReaderRepository.cleanup()
+                } catch (e: Exception) {
+                    Log.e("PdfViewModel", "Error during cleanup", e)
+                }
+            }
         }
+        super.onCleared()
     }
 }

--- a/app/src/main/java/com/asaad27/qraya/ui/pdf/viewmodel/PdfViewModel.kt
+++ b/app/src/main/java/com/asaad27/qraya/ui/pdf/viewmodel/PdfViewModel.kt
@@ -9,7 +9,6 @@ import com.asaad27.qraya.ui.pdf.model.PdfDocumentState
 import com.asaad27.qraya.ui.pdf.model.PdfLoadingState
 import com.asaad27.qraya.ui.pdf.model.PdfPageState
 import com.asaad27.qraya.ui.pdf.model.PdfUiState
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
@@ -29,32 +28,16 @@ class PdfViewModel(
         currentUri = uri
 
         viewModelScope.launch {
+            updateLoadingState(PdfLoadingState.Loading)
             try {
-                _pdfState.update {
-                    it.copy(
-                        pdfDocumentState = PdfDocumentState(
-                            loadingState = PdfLoadingState.Loading,
-                            pageCount = 0u
-                        ),
-                        currentPageState = PdfPageState(PdfLoadingState.Loading, 0u)
-                    )
-                }
-
                 pdfReaderRepository.loadPdf(uri).fold(
                     onSuccess = { pdfInfo ->
-                        _pdfState.update {
-                            it.copy(
-                                pdfDocumentState = PdfDocumentState(
-                                    loadingState = PdfLoadingState.Success,
-                                    pageCount = pdfInfo.pageCount.toUInt()
-                                ),
-                                currentPageState = PdfPageState(PdfLoadingState.Success, 0u)
-                            )
-                        }
+                        updateLoadingState(
+                            PdfLoadingState.Success,
+                            pdfInfo.pageCount.toUInt()
+                        )
                     },
-                    onFailure = { exception ->
-                        handleError(exception)
-                    }
+                    onFailure = { handleError(it) }
                 )
             } catch (e: Exception) {
                 handleError(e)
@@ -63,19 +46,34 @@ class PdfViewModel(
     }
 
     suspend fun renderPage(pageIndex: Int, width: Int, height: Int): Bitmap {
-        return pdfReaderRepository.renderPage(pageIndex, width, height).getOrThrow()
-    }
+        return pdfReaderRepository.renderPage(pageIndex, width, height)
+            .onSuccess { updatePageState(PdfLoadingState.Success, pageIndex.toUInt()) }
+            .getOrThrow()
+        }
 
     suspend fun renderPagesAsync(pages: List<Int>, width: Int, height: Int): List<Bitmap> {
-        return pdfReaderRepository.renderPages(pages, width, height).getOrThrow()
+        return pdfReaderRepository.renderPages(pages, width, height)
+            .onSuccess { updateLoadingState(PdfLoadingState.Success) }
+            .getOrThrow()
     }
 
-    fun renderPagesFlow(
-        pages: List<Int>,
-        width: Int,
-        height: Int
-    ): Flow<Result<Pair<Int, Bitmap>>> {
-        return pdfReaderRepository.renderPagesFlow(pages, width, height)
+    private fun updateLoadingState(state: PdfLoadingState, pageCount: UInt = _pdfState.value.pdfDocumentState.pageCount) {
+        _pdfState.update {
+            it.copy(
+                pdfDocumentState = it.pdfDocumentState.copy(
+                    loadingState = state,
+                    pageCount = pageCount
+                )
+            )
+        }
+    }
+
+    private fun updatePageState(state: PdfLoadingState, pageNumber: UInt) {
+        _pdfState.update {
+            it.copy(
+                currentPageState = PdfPageState(state, pageNumber)
+            )
+        }
     }
 
     private fun handleError(exception: Throwable) {
@@ -96,6 +94,8 @@ class PdfViewModel(
 
     public override fun onCleared() {
         super.onCleared()
-        pdfReaderRepository.cleanup()
+        viewModelScope.launch {
+            pdfReaderRepository.cleanup()
+        }
     }
 }

--- a/app/src/test/java/com/asaad27/qraya/data/repository/PdfReaderRepositoryTest.kt
+++ b/app/src/test/java/com/asaad27/qraya/data/repository/PdfReaderRepositoryTest.kt
@@ -72,8 +72,6 @@ class PdfReaderRepositoryTest {
         // When
         val result = repository.loadPdf(uri)
 
-        assertTrue(result.isFailure)
-        assertEquals("Failed to open PDF file descriptor", result.exceptionOrNull()?.message)
         // Then
         assertThat(result.isFailure)
             .withFailMessage("Result should be successful, found: ${result.exceptionOrNull()?.message}")
@@ -148,6 +146,174 @@ class PdfReaderRepositoryTest {
             .isEqualTo(0)
         assertThat(results[1].getOrNull()?.first)
             .isEqualTo(1)
+    }
+
+    @Test
+    fun `renderer pool properly manages renderers`() = runTest(testDispatcher) {
+        // Given
+        val uri = mockk<Uri>()
+        val fileDescriptor = mockk<ParcelFileDescriptor>(relaxed = true)
+        val mockBitmap = mockk<Bitmap>(relaxed = true)
+
+        every { Bitmap.createBitmap(any(), any(), any()) } returns mockBitmap
+        every { context.contentResolver.openFileDescriptor(uri, "r") } returns fileDescriptor
+
+        // When
+        repository.loadPdf(uri).getOrThrow()
+        val result = repository.renderPage(0, 300, 400)
+
+        // Then
+        assertThat(result.isSuccess)
+            .withFailMessage("Result should be successful, found: ${result.exceptionOrNull()?.message}")
+            .isTrue
+        assertThat(repository.getActiveRenderersCount())
+            .isEqualTo(Runtime.getRuntime().availableProcessors())
+    }
+
+    @Test
+    fun `renderer pool initializes with correct number of renderers`() = runTest(testDispatcher) {
+        // Given
+        val uri = mockk<Uri>()
+        val fileDescriptor = mockk<ParcelFileDescriptor>(relaxed = true)
+        every { context.contentResolver.openFileDescriptor(uri, "r") } returns fileDescriptor
+
+        // When
+        repository.loadPdf(uri).getOrThrow()
+
+        // Then
+        // After initialization, all renderers should be both active and in the pool
+        val expectedCount = Runtime.getRuntime().availableProcessors()
+        val activeCount = repository.getActiveRenderersCount()
+        val poolCount = repository.getPooledRenderersCount()
+        assertThat(activeCount)
+            .withFailMessage("All renderers should be active, found: $activeCount, expected: $expectedCount")
+            .isEqualTo(expectedCount)
+        assertThat(poolCount)
+            .withFailMessage("All renderers should be in the pool, found: $poolCount, expected: $expectedCount")
+            .isEqualTo(expectedCount)
+    }
+
+    @Test
+    fun `renderer is returned to pool after use`() = runTest(testDispatcher) {
+        // Given
+        val uri = mockk<Uri>()
+        val fileDescriptor = mockk<ParcelFileDescriptor>(relaxed = true)
+        val mockBitmap = mockk<Bitmap>(relaxed = true)
+        every { context.contentResolver.openFileDescriptor(uri, "r") } returns fileDescriptor
+        every { Bitmap.createBitmap(any(), any(), any()) } returns mockBitmap
+
+        // When
+        repository.loadPdf(uri).getOrThrow()
+        val initialPoolCount = repository.getPooledRenderersCount()
+        repository.renderPage(0, 100, 100)  // This will use and return a renderer
+        val finalPoolCount = repository.getPooledRenderersCount()
+
+        // Then
+        assertThat(finalPoolCount)
+            .withFailMessage("Pool should have same count after renderer is returned, found: $finalPoolCount, expected: $initialPoolCount")
+            .isEqualTo(initialPoolCount)
+    }
+
+    @Test
+    fun `concurrent page renders use different renderers`() = runTest(testDispatcher) {
+        // Given
+        val uri = mockk<Uri>()
+        val fileDescriptor = mockk<ParcelFileDescriptor>(relaxed = true)
+        val mockBitmap = mockk<Bitmap>(relaxed = true)
+        every { context.contentResolver.openFileDescriptor(uri, "r") } returns fileDescriptor
+        every { Bitmap.createBitmap(any(), any(), any()) } returns mockBitmap
+
+        repository.loadPdf(uri).getOrThrow()
+        val initialPoolCount = repository.getPooledRenderersCount()
+
+        // When - Render multiple pages concurrently
+        val results = coroutineScope {
+            (0..3).map { pageIndex ->
+                async {
+                    repository.renderPage(pageIndex, 100, 100)
+                }
+            }.awaitAll()
+        }
+
+        // Then
+        assertThat(results)
+            .withFailMessage("All renders should succeed")
+            .allMatch { it.isSuccess }
+
+        // Verify renderers were returned
+        val poolCount = repository.getPooledRenderersCount()
+        assertThat(poolCount)
+            .withFailMessage("All renderers should be returned to pool, found: $poolCount, expected: $initialPoolCount")
+            .isEqualTo(initialPoolCount)
+    }
+
+    @Test
+    fun `cleanup properly releases all resources`() = runTest(testDispatcher) {
+        // Given
+        val uri = mockk<Uri>()
+        val fileDescriptor = mockk<ParcelFileDescriptor>(relaxed = true)
+        every { context.contentResolver.openFileDescriptor(uri, "r") } returns fileDescriptor
+
+        // When
+        repository.loadPdf(uri).getOrThrow()
+        repository.cleanup()
+
+        // Then
+        val activeRenderers = repository.getActiveRenderersCount()
+        val poolCount = repository.getPooledRenderersCount()
+        assertThat(activeRenderers)
+            .withFailMessage("No renderers should remain active after cleanup, found: $activeRenderers")
+            .isZero()
+        assertThat(poolCount)
+            .withFailMessage("Pool should be empty after cleanup, found: $poolCount")
+            .isZero()
+    }
+
+    @Test
+    fun `loading new PDF cleans up previous resources`() = runTest(testDispatcher) {
+        // Given
+        val uri1 = mockk<Uri>()
+        val uri2 = mockk<Uri>()
+        val fileDescriptor = mockk<ParcelFileDescriptor>(relaxed = true)
+        every { context.contentResolver.openFileDescriptor(any(), any()) } returns fileDescriptor
+
+        // When
+        repository.loadPdf(uri1).getOrThrow()
+        val firstLoadRenderers = repository.getActiveRenderersCount()
+
+        repository.loadPdf(uri2).getOrThrow()
+        val secondLoadRenderers = repository.getActiveRenderersCount()
+
+        // Then
+        val expectedCount = Runtime.getRuntime().availableProcessors()
+        assertThat(firstLoadRenderers)
+            .withFailMessage("Expected $expectedCount renderers for first load but found $firstLoadRenderers")
+            .isEqualTo(expectedCount)
+        assertThat(secondLoadRenderers)
+            .withFailMessage("Expected $expectedCount renderers for second load but found $secondLoadRenderers")
+            .isEqualTo(expectedCount)
+    }
+
+    @Test
+    fun `renderer pool handles errors gracefully`() = runTest(testDispatcher) {
+        // Given
+        val uri = mockk<Uri>()
+        val fileDescriptor = mockk<ParcelFileDescriptor>(relaxed = true)
+        val mockBitmap = mockk<Bitmap>(relaxed = true)
+        every { context.contentResolver.openFileDescriptor(uri, "r") } returns fileDescriptor
+        every { Bitmap.createBitmap(any(), any(), any()) } returns mockBitmap
+
+        repository.loadPdf(uri).getOrThrow()
+        val initialPoolCount = repository.getPooledRenderersCount()
+
+        // When - Simulate a renderer that throws an exception
+        repository.renderPage(0, 100, 100)
+
+        // Then
+        val poolCount = repository.getPooledRenderersCount()
+        assertThat(poolCount)
+            .withFailMessage("Renderer should be returned to pool even after error, found: $poolCount, expected: $initialPoolCount")
+            .isEqualTo(initialPoolCount)
     }
 
     @After

--- a/app/src/test/java/com/asaad27/qraya/data/repository/PdfReaderRepositoryTest.kt
+++ b/app/src/test/java/com/asaad27/qraya/data/repository/PdfReaderRepositoryTest.kt
@@ -10,10 +10,13 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertTrue
+import org.assertj.core.api.Assertions.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
@@ -23,12 +26,15 @@ import org.junit.Test
 class PdfReaderRepositoryTest {
     private lateinit var repository: PdfReaderRepository
     private lateinit var context: Context
-    private val testDispatcher = StandardTestDispatcher()
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private val testDispatcher = UnconfinedTestDispatcher()
 
     @Before
     fun setup() {
         context = mockk(relaxed = true)
         mockkStatic(Bitmap::class)
+        mockkStatic(Bitmap::class, ParcelFileDescriptor::class)
+        every { ParcelFileDescriptor.dup(any()) } returns mockk(relaxed = true)
         val mockMatrix = mockk<Matrix>(relaxed = true)
 
         repository = PdfReaderRepository(
@@ -41,29 +47,42 @@ class PdfReaderRepositoryTest {
 
     @Test
     fun `loadPdf returns correct page count`() = runTest(testDispatcher) {
+        // Given
         val uri = mockk<Uri>()
         val fileDescriptor = mockk<ParcelFileDescriptor>(relaxed = true)
         every { context.contentResolver.openFileDescriptor(uri, "r") } returns fileDescriptor
 
+        // When
         val result = repository.loadPdf(uri)
 
-        assertTrue(result.isSuccess)
-        assertEquals(2, result.getOrNull()?.pageCount)
+        // Then
+        assertThat(result.isSuccess)
+            .withFailMessage("Result should be successful, found: ${result.exceptionOrNull()?.message}")
+            .isTrue
+        assertThat(result.getOrNull()?.pageCount)
+            .isEqualTo(2)
     }
 
     @Test
     fun `loadPdf returns failure when file descriptor is null`() = runTest(testDispatcher) {
+        // Given
         val uri = mockk<Uri>()
         every { context.contentResolver.openFileDescriptor(uri, "r") } returns null
 
+        // When
         val result = repository.loadPdf(uri)
 
         assertTrue(result.isFailure)
         assertEquals("Failed to open PDF file descriptor", result.exceptionOrNull()?.message)
+        // Then
+        assertThat(result.isFailure)
+            .withFailMessage("Result should be successful, found: ${result.exceptionOrNull()?.message}")
+            .isTrue
     }
 
     @Test
     fun `renderPage returns bitmap with correct dimensions`() = runTest(testDispatcher) {
+        // Given
         val uri = mockk<Uri>()
         val fileDescriptor = mockk<ParcelFileDescriptor>(relaxed = true)
         val mockBitmap = mockk<Bitmap>(relaxed = true)
@@ -71,44 +90,64 @@ class PdfReaderRepositoryTest {
         every { context.contentResolver.openFileDescriptor(uri, "r") } returns fileDescriptor
         every { Bitmap.createBitmap(any(), any(), any()) } returns mockBitmap
 
+        // When
         repository.loadPdf(uri).getOrThrow()
         val result = repository.renderPage(0, 300, 400)
 
-        assertTrue(result.isSuccess)
-        assertEquals(mockBitmap, result.getOrNull())
+        // Then
+        assertThat(result.isSuccess)
+            .withFailMessage("Result should be successful, found: ${result.exceptionOrNull()?.message}")
+            .isTrue
+        assertThat(result.getOrNull())
+            .withFailMessage("Result should contain a bitmap")
+            .isEqualTo(mockBitmap)
     }
 
     @Test
     fun `renderPages returns list of bitmaps`() = runTest(testDispatcher) {
+        // Given
         val uri = mockk<Uri>()
         val fileDescriptor = mockk<ParcelFileDescriptor>(relaxed = true)
         val mockBitmap = mockk<Bitmap>(relaxed = true)
         every { context.contentResolver.openFileDescriptor(uri, "r") } returns fileDescriptor
         every { Bitmap.createBitmap(any(), any(), any()) } returns mockBitmap
 
+        // When
         repository.loadPdf(uri).getOrThrow()
         val result = repository.renderPages(listOf(0, 1), 300, 400)
 
-        assertTrue(result.isSuccess)
-        assertEquals(2, result.getOrNull()?.size)
+        // Then
+        assertThat(result.isSuccess)
+            .withFailMessage("Result should be successful, found: ${result.exceptionOrNull()?.message}")
+            .isTrue
+        assertThat(result.getOrNull()?.size)
+            .isEqualTo(2)
     }
 
     @Test
     fun `renderPagesFlow emits bitmaps sequentially`() = runTest(testDispatcher) {
+        // Given
         val uri = mockk<Uri>()
         val fileDescriptor = mockk<ParcelFileDescriptor>(relaxed = true)
         val mockBitmap = mockk<Bitmap>(relaxed = true)
         every { context.contentResolver.openFileDescriptor(uri, "r") } returns fileDescriptor
         every { Bitmap.createBitmap(any(), any(), any()) } returns mockBitmap
 
+        // When
         repository.loadPdf(uri).getOrThrow()
         val results = mutableListOf<Result<Pair<Int, Bitmap>>>()
         repository.renderPagesFlow(listOf(0, 1), 300, 400).collect { results.add(it) }
 
-        assertEquals(2, results.size)
-        assertTrue(results.all { it.isSuccess })
-        assertEquals(0, results[0].getOrNull()?.first)
-        assertEquals(1, results[1].getOrNull()?.first)
+        // Then
+        assertThat(results.size)
+            .isEqualTo(2)
+        assertThat(results.all { it.isSuccess })
+            .withFailMessage("All results should be successful")
+            .isTrue
+        assertThat(results[0].getOrNull()?.first)
+            .isEqualTo(0)
+        assertThat(results[1].getOrNull()?.first)
+            .isEqualTo(1)
     }
 
     @After

--- a/app/src/test/java/com/asaad27/qraya/data/repository/PdfReaderRepositoryTest.kt
+++ b/app/src/test/java/com/asaad27/qraya/data/repository/PdfReaderRepositoryTest.kt
@@ -12,6 +12,7 @@ import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -112,7 +113,9 @@ class PdfReaderRepositoryTest {
 
     @After
     fun tearDown() {
-        repository.cleanup()
+        runBlocking {
+            repository.cleanup()
+        }
         unmockkAll()
     }
 

--- a/app/src/test/java/com/asaad27/qraya/ui/pdf/viewmodel/PdfViewModelTest.kt
+++ b/app/src/test/java/com/asaad27/qraya/ui/pdf/viewmodel/PdfViewModelTest.kt
@@ -115,26 +115,6 @@ class PdfViewModelTest : KoinTest {
     }
 
     @Test
-    fun `renderPagesFlow should emit bitmaps correctly`() = runTest {
-        // Given
-        val mockBitmap = mockk<Bitmap>()
-        val pages = listOf(0, 1)
-        declareMock<IPdfReaderRepository> {
-            every {
-                renderPagesFlow(pages = pages, width = 100, height = 100)
-            } returns flowOf(Result.success(0 to mockBitmap))
-        }
-
-        // When
-        val flow = viewModel.renderPagesFlow(pages, 100, 100)
-
-        // Then
-        flow.collect { result ->
-            assertEquals(Result.success(0 to mockBitmap), result)
-        }
-    }
-
-    @Test
     fun `renderPages should return list of bitmaps on success`() = runTest {
         // Given
         val mockBitmap = mockk<Bitmap>()
@@ -176,7 +156,7 @@ class PdfViewModelTest : KoinTest {
         // Given
         var cleanupCalled = false
         declareMock<IPdfReaderRepository> {
-            every { cleanup() } answers { cleanupCalled = true }
+            coEvery { cleanup() } answers { cleanupCalled = true }
         }
 
         // When

--- a/app/src/test/java/com/asaad27/qraya/ui/pdf/viewmodel/PdfViewModelTest.kt
+++ b/app/src/test/java/com/asaad27/qraya/ui/pdf/viewmodel/PdfViewModelTest.kt
@@ -6,18 +6,18 @@ import com.asaad27.qraya.data.model.PdfInfo
 import com.asaad27.qraya.data.repository.IPdfReaderRepository
 import com.asaad27.qraya.ui.pdf.model.PdfLoadingState
 import io.mockk.coEvery
-import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkClass
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.After
-import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -74,8 +74,10 @@ class PdfViewModelTest : KoinTest {
 
         // Then
         val currentState = viewModel.pdfState.value
-        assertEquals(PdfLoadingState.Success, currentState.pdfDocumentState.loadingState)
-        assertEquals(5u, currentState.pdfDocumentState.pageCount)
+        assertThat(currentState.pdfDocumentState.loadingState)
+            .isEqualTo(PdfLoadingState.Success)
+        assertThat(currentState.pdfDocumentState.pageCount)
+            .isEqualTo(5u)
     }
 
     @Test
@@ -93,8 +95,10 @@ class PdfViewModelTest : KoinTest {
 
         // Then
         val currentState = viewModel.pdfState.value
-        assert(currentState.pdfDocumentState.loadingState is PdfLoadingState.Error)
-        assertEquals(0u, currentState.pdfDocumentState.pageCount)
+        assertThat(currentState.pdfDocumentState.loadingState)
+            .isInstanceOf(PdfLoadingState.Error::class.java)
+        assertThat(currentState.pdfDocumentState.pageCount)
+            .isEqualTo(0u)
     }
 
     @Test
@@ -111,7 +115,8 @@ class PdfViewModelTest : KoinTest {
         val result = viewModel.renderPage(pageIndex = 0, width = 100, height = 100)
 
         // Then
-        assertEquals(mockBitmap, result)
+        assertThat(result)
+            .isEqualTo(mockBitmap)
     }
 
     @Test
@@ -129,7 +134,8 @@ class PdfViewModelTest : KoinTest {
         val result = viewModel.renderPagesAsync(pages = pages, width = 100, height = 100)
 
         // Then
-        assertEquals(listOf(mockBitmap, mockBitmap), result)
+        assertThat(result)
+            .isEqualTo(listOf(mockBitmap, mockBitmap))
     }
 
     @Test
@@ -143,12 +149,13 @@ class PdfViewModelTest : KoinTest {
         }
 
         // When & Then
-        try {
-            viewModel.renderPage(0, 100, 100)
-            assert(false) { "Expected exception was not thrown" }
-        } catch (e: RuntimeException) {
-            assertEquals("Render failed", e.message)
+        assertThatThrownBy {
+            runBlocking {
+                viewModel.renderPage(0, 100, 100)
+            }
         }
+            .isInstanceOf(RuntimeException::class.java)
+            .hasMessage("Render failed")
     }
 
     @Test
@@ -161,9 +168,12 @@ class PdfViewModelTest : KoinTest {
 
         // When
         viewModel.onCleared()
+        testDispatcher.scheduler.advanceUntilIdle() // Wait for the coroutine to complete
 
         // Then
-        assert(cleanupCalled) { "Cleanup was not called" }
+        assertThat(cleanupCalled)
+            .withFailMessage("Cleanup should have been called")
+            .isTrue()
     }
 
     @Test
@@ -183,8 +193,10 @@ class PdfViewModelTest : KoinTest {
 
         // Then
         val currentState = viewModel.pdfState.value
-        assertEquals(PdfLoadingState.Success, currentState.pdfDocumentState.loadingState)
-        assertEquals(1u, currentState.pdfDocumentState.pageCount)
+        assertThat(currentState.pdfDocumentState.loadingState)
+            .isEqualTo(PdfLoadingState.Success)
+        assertThat(currentState.pdfDocumentState.pageCount)
+            .isEqualTo(1u)
     }
 
     @Test
@@ -205,7 +217,9 @@ class PdfViewModelTest : KoinTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         // Then
-        assertEquals(1, loadCount)
+        assertThat(loadCount)
+            .withFailMessage("PDF should only be loaded once for the same URI, found: $loadCount")
+            .isEqualTo(1)
     }
 
     @Test
@@ -223,16 +237,23 @@ class PdfViewModelTest : KoinTest {
 
         // Then
         val currentState = viewModel.pdfState.value
-        assert(currentState.pdfDocumentState.loadingState is PdfLoadingState.Error)
+        assertThat(currentState.pdfDocumentState.loadingState)
+            .isInstanceOf(PdfLoadingState.Error::class.java)
+        assertThat(currentState.pdfDocumentState.pageCount)
+            .isEqualTo(0u)
     }
 
     @Test
     fun `initial pdfState should be in Idle state`() {
         // Then
         val currentState = viewModel.pdfState.value
-        assertEquals(PdfLoadingState.Initial, currentState.pdfDocumentState.loadingState)
-        assertEquals(0u, currentState.pdfDocumentState.pageCount)
-        assertEquals(PdfLoadingState.Initial, currentState.currentPageState.loadingState)
-        assertEquals(0u, currentState.currentPageState.pageNumber)
+        assertThat(currentState.pdfDocumentState.loadingState)
+            .isEqualTo(PdfLoadingState.Initial)
+        assertThat(currentState.pdfDocumentState.pageCount)
+            .isEqualTo(0u)
+        assertThat(currentState.currentPageState.loadingState)
+            .isEqualTo(PdfLoadingState.Initial)
+        assertThat(currentState.currentPageState.pageNumber)
+            .isEqualTo(0u)
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "8.7.3"
+assertjCore = "3.27.0"
 coilCompose = "3.0.4"
 koinAndroid = "4.0.1"
 kotlin = "2.1.0"
@@ -23,6 +24,7 @@ scenecore = "1.0.0-alpha01"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertjCore" }
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coilCompose" }
 coil-network-ktor3 = { module = "io.coil-kt.coil3:coil-network-ktor3", version.ref = "coilCompose" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }


### PR DESCRIPTION
This commit introduces several improvements to PDF rendering performance and resource management:

- Implemented a renderer pool to reuse PdfRenderers, reducing object creation overhead.
- Added batching for rendering multiple pages, distributing the workload across available renderers.
- Improved cleanup logic to ensure resources are properly released when no longer needed.
- Updated `PdfReaderRepository` to use suspend functions for cleanup and resource management.
- Removed `renderPagesFlow` from the `PdfViewModel` and refactored rendering logic.
- Refactored error handling in `PdfViewModel` for better clarity.