### PR TITLE
temp: Add logging mocks to PdfReaderRepositoryTest

### DIFF
--- a/app/src/main/java/com/asaad27/qraya/data/repository/PdfReaderRepository.kt
+++ b/app/src/main/java/com/asaad27/qraya/data/repository/PdfReaderRepository.kt
@@ -21,12 +21,9 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
-import okio.Timeout
 import java.util.concurrent.ConcurrentLinkedQueue
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
-import kotlin.time.DurationUnit
-import kotlin.time.toDuration
 
 class PdfReaderRepository(
     private val applicationContext: Context,

--- a/app/src/test/java/com/asaad27/qraya/data/repository/PdfReaderRepositoryTest.kt
+++ b/app/src/test/java/com/asaad27/qraya/data/repository/PdfReaderRepositoryTest.kt
@@ -6,6 +6,7 @@ import android.graphics.Matrix
 import android.graphics.Rect
 import android.net.Uri
 import android.os.ParcelFileDescriptor
+import android.util.Log
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
@@ -43,6 +44,12 @@ class PdfReaderRepositoryTest {
             rendererFactory = { TestPdfRenderer(pageCount = 2) },
             matrixFactory = { mockMatrix }
         )
+
+        mockkStatic(Log::class)
+        every { Log.v(any(), any()) } returns 0
+        every { Log.d(any(), any()) } returns 0
+        every { Log.i(any(), any()) } returns 0
+        every { Log.e(any(), any()) } returns 0
     }
 
     @Test


### PR DESCRIPTION
adds logging mocks to the `PdfReaderRepositoryTest` to suppress log output during testing, otherwise it fails, can think about a cleaner solution later when I implement proper logging